### PR TITLE
Fix for issue #1

### DIFF
--- a/lib/mite-rb.rb
+++ b/lib/mite-rb.rb
@@ -1,5 +1,6 @@
 require 'active_support'
 require 'active_resource'
+require 'mite/version.rb'
 
 # The official ruby library for interacting with the RESTful API of mite,
 # a sleek time tracking webapp.


### PR DESCRIPTION
The `require *` at the bottom of mite-rb.rb is a bit late for the version number which is used beforehand in the line `self.user_agent    = "mite-rb/#{Mite::VERSION}"`
