### PR TITLE
Don't define Mite::VERSION twice

### DIFF
--- a/lib/mite/version.rb
+++ b/lib/mite/version.rb
@@ -1,3 +1,5 @@
 module Mite
-  VERSION = "0.4.3"
+  unless const_defined?(:VERSION)
+    VERSION = "0.4.3"
+  end
 end


### PR DESCRIPTION
The change implemented in 15ccd493da6678d2eb6aefaadc7dbaa48c0d9dd1 causes lib/mite/version.rb to be required twice; once explicitly at lib/mite-rb.rb#3 and once as part of the auto-require-hack at lib/mite-rb.rb#182.

This in turn results in a warning whenever mite-rb is loaded:

```
./lib/mite/version.rb:2: warning: already initialized constant VERSION
```

This commit fixes that warning, however the proper way to do it would probably be to explicitly require files instead of the automatic require everything.
