### PR TITLE
Lock down max support version of Active Support

### DIFF
--- a/mite-rb.gemspec
+++ b/mite-rb.gemspec
@@ -20,5 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_runtime_dependency(%q<activeresource>, [">= 2.3.14"])
+  s.add_runtime_dependency(%q<activesupport>, ["<= 3.0.9"])
+
 end
 


### PR DESCRIPTION
`Mite::TimeEntryGroup.find_every` uses `Object#returning, which has been deprecated in ActiveSupport`. Most recent version with support for `Object#returning` is [3.0.9](http://apidock.com/rails/Object/returning).

For Ruby 1.9 Object#tap can be used instead of Object#returning, but I am not sure where on the roadmap dropping support for Ruby 1.8 is?
